### PR TITLE
More robust check for running under node

### DIFF
--- a/lib/crc.js
+++ b/lib/crc.js
@@ -399,7 +399,7 @@
 
 	var target, property;
 
-	if(typeof(window) == 'undefined')
+	if(typeof(module) !== 'undefined' && module.exports)
 	{
 		target = module;
 		property = 'exports';


### PR DESCRIPTION
Check if module.exports exists, since this is a more reliable check if
we are running under node. Checking for window conflicts with some
node modules like d3 that define a global window object.
