### PR TITLE
Add UMD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JavaScript CRC 8, 16 and 32.
 
-This is a basic port/copy of the JavaScript CRC implementation. The module works with any CommonJS system supporting `module.exports` notation as well as in the browser. When loaded in the browser, all functions end up under the `window.crc` "namespace".
+This is a basic port/copy of the JavaScript CRC implementation. The module works with any CommonJS system supporting `module.exports` notation, AMD, and the browser. When loaded in the browser, all functions end up under the `window.crc` "namespace".
 
 Original code is taken from http://www.digsys.se/JavaScript/CRC.aspx 
 

--- a/lib/crc.js
+++ b/lib/crc.js
@@ -1,4 +1,15 @@
-(function()
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define(factory);
+    } else if (typeof exports === 'object') {
+        // Node.
+        module.exports = factory();
+    } else {
+        // Browser globals (root is window)
+        root.returnExports = factory();
+  }
+}(this, function()
 {
 	// CRC-8 in table form
 	// 
@@ -400,20 +411,7 @@
 		return hex16(val >> 16) + hex16(val);
 	};
 
-	var target, property;
-
-	if(typeof(window) == 'undefined')
-	{
-		target = module;
-		property = 'exports';
-	}
-	else
-	{
-		target = window;
-		property = 'crc';
-	}
-
-	target[property] = {
+	return {
 		'crc8'    : crc8,
 		'crcArc'  : crcArc,
 		'crcModbusString' : crcModbusString,
@@ -430,4 +428,4 @@
 			crc32 : crc32Buffer
 		}
 	};
-})();
+}));


### PR DESCRIPTION
Based on https://github.com/umdjs/umd/blob/master/returnExports.js, this method
plays nicely with commonjs-in-the-browser environments like Browserify
as well as AMD loader systems. It prefers these modules systems over
attaching to the global window object, which it uses as a fallback.
