### PR TITLE
drop redundant badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # crc
 
-[![NPM version](https://badge.fury.io/js/crc.svg)](http://badge.fury.io/js/crc)
 [![Dependency status](https://david-dm.org/alexgorbatchev/node-crc.svg)](https://david-dm.org/alexgorbatchev/node-crc)
 [![devDependency Status](https://david-dm.org/alexgorbatchev/node-crc/dev-status.svg)](https://david-dm.org/alexgorbatchev/node-crc#info=devDependencies)
 [![Build Status](https://api.travis-ci.org/alexgorbatchev/node-crc.svg?branch=master)](https://travis-ci.org/alexgorbatchev/node-crc)


### PR DESCRIPTION
The larger nodei.co badge (below) already has the npm package's version.
