### PR TITLE
fix README.md: a synchronous reading of a file is implied

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Calculate a CRC32:
 
 Calculate a CRC32 of a file:
 
-    crc.crc32(fs.readFileAsync('README.md', 'utf8'));
+    crc.crc32(fs.readFileSync('README.md', 'utf8'));
     # => "127ad531"
 
 Incrementally calculate a CRC32:


### PR DESCRIPTION
There's no `fs.readFileAsync`; you must have meant `.readFileSync`.
