### PR TITLE
Two small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ crc32(fs.readFileSync('README.md', 'utf8')).toString(16);
 Or using a `Buffer`:
 
 ```js
-crc32(fs.readFileSync('README.md', 'utf8')).toString(16);
+crc32(fs.readFileSync('README.md')).toString(16);
 // "127ad531"
 ```
 

--- a/test/test_helpers.js
+++ b/test/test_helpers.js
@@ -27,7 +27,7 @@ export default function crcSuiteFor({ crc, value, expected, initial }) {
 
     exec(`${__dirname}/pycrc/${cmd}`, (err, reference) => {
       fs.unlinkSync(filename);
-      callback(err, (reference || '').replace(/^0x|\n$/g, ''));
+      callback(err, (reference || '').replace(/^0x|\n$|\r\n$/g, ''));
     });
   }
 
@@ -38,7 +38,7 @@ export default function crcSuiteFor({ crc, value, expected, initial }) {
     const cmd = `pycrc.py --model=${model} ${initial} --check-string="${string}"`;
 
     exec(`${__dirname}/pycrc/${cmd}`, (err, reference) =>
-      callback(err, (reference || '').replace(/^0x|\n$/g, ''))
+      callback(err, (reference || '').replace(/^0x|\n$|\r\n$/g, ''))
     );
   }
 


### PR DESCRIPTION
#### Fix "using a buffer" example
Shouldn't spec an encoding -- that makes it a string

#### Make tests run on Windows
Need to tolerate \r\n.