### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+arch:
+ - amd64
+ - ppc64le
 sudo: false
 node_js:
   - "6.2.2"


### PR DESCRIPTION
Hi,
I had added ppc64le support on Travis-ci and Its been success added and build. Kindly review and merge same.

Changes done are added ppc64le arch 

The Travis ci build logs can be verified from the link below.
https://travis-ci.com/github/zazzel/node-crc
Please have a look.

Thank you
