### PR TITLE
fix: add crc8dvbs2 to cjs-default-unwrap

### DIFF
--- a/dist/cjs-default-unwrap/crc8dvbs2.js
+++ b/dist/cjs-default-unwrap/crc8dvbs2.js
@@ -1,0 +1,3 @@
+const results = require('../cjs/crc8dvbs2').default;
+module.exports = results;
+module.exports.default = results;


### PR DESCRIPTION
`crc8dvbs2` is missing in CommonJS Default Unwrap Folder